### PR TITLE
Use os.environ.get for SENTRY_DSN to avoid KeyError if not set

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -15,7 +15,7 @@ class Settings:
     GEMINI_API_KEY = os.environ["GOOGLE_API_KEY"]
     TG_API_TOKEN = os.environ["TG_API_TOKEN"]
     AUTH_LIST = os.environ["AUTH_LIST"].split(",")
-    SENTRY_DSN = os.environ["SENTRY_DSN"]
+    SENTRY_DSN = os.environ.get("SENTRY_DSN")
     REWRITE_PROMPT = False
 
 


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Replaced `os.environ` access with `os.environ.get` for `SENTRY_DSN`.

- Prevents `KeyError` if `SENTRY_DSN` is not set in the environment.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config.py</strong><dd><code>Use `os.environ.get` for `SENTRY_DSN` to prevent errors</code>&nbsp; &nbsp; </dd></summary>
<hr>

src/config.py

<li>Changed <code>os.environ["SENTRY_DSN"]</code> to <code>os.environ.get("SENTRY_DSN")</code>.<br> <li> Ensures safe access to <code>SENTRY_DSN</code> environment variable.


</details>


  </td>
  <td><a href="https://github.com/TradingX-TF/rag-support-bot/pull/11/files#diff-24a3fe5c783755412cb9de83238b4dfd0699345bf50dcadc3ec23c6749361592">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>