### PR TITLE
Refactor user_id column to use BigInteger type for improved scalability

### DIFF
--- a/src/db.py
+++ b/src/db.py
@@ -12,7 +12,7 @@ Base = declarative_base()
 class UsersOrm(Base):
     __tablename__ = "users"
 
-    user_id = Column(BigInteger, primary_key=True, autoincrement=False)
+    user_id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=False)
     first_name: Mapped[str | None]
     last_name: Mapped[str | None]
     username: Mapped[str | None]

--- a/src/db.py
+++ b/src/db.py
@@ -1,4 +1,4 @@
-from sqlalchemy import ARRAY, BigInteger, Column, String, create_engine
+from sqlalchemy import ARRAY, BigInteger, String, create_engine
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 from sqlalchemy.ext.declarative import declarative_base
@@ -12,12 +12,16 @@ Base = declarative_base()
 class UsersOrm(Base):
     __tablename__ = "users"
 
-    user_id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=False)
+    user_id: Mapped[int] = mapped_column(
+        BigInteger,
+        primary_key=True,
+        autoincrement=False,
+    )
     first_name: Mapped[str | None]
     last_name: Mapped[str | None]
     username: Mapped[str | None]
     approved: Mapped[bool] = mapped_column(server_default="False")
-    roles = mapped_column(ARRAY(String))
+    roles: Mapped[list] = mapped_column(ARRAY(String))
 
 
 sync_engine = create_engine(settings.DATABASE_URL, echo=False)

--- a/src/db.py
+++ b/src/db.py
@@ -1,4 +1,4 @@
-from sqlalchemy import ARRAY, String, create_engine
+from sqlalchemy import ARRAY, BigInteger, Column, String, create_engine
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 from sqlalchemy.ext.declarative import declarative_base
@@ -12,7 +12,7 @@ Base = declarative_base()
 class UsersOrm(Base):
     __tablename__ = "users"
 
-    user_id: Mapped[int] = mapped_column(primary_key=True)
+    user_id = Column(BigInteger, primary_key=True, autoincrement=False)
     first_name: Mapped[str | None]
     last_name: Mapped[str | None]
     username: Mapped[str | None]


### PR DESCRIPTION
### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Refactored `user_id` column to use `BigInteger` for scalability.

- Updated `UsersOrm` model to reflect new column type.

- Added `Column` and `BigInteger` imports to support changes.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>db.py</strong><dd><code>Refactored `user_id` column and updated imports</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/db.py

<li>Changed <code>user_id</code> column type to <code>BigInteger</code>.<br> <li> Updated <code>UsersOrm</code> model to use <code>Column</code> with <code>BigInteger</code>.<br> <li> Added necessary imports for <code>Column</code> and <code>BigInteger</code>.


</details>


  </td>
  <td><a href="https://github.com/TradingX-TF/rag-support-bot/pull/44/files#diff-6045026f204d0e038fb8eaf86675588c01bd88d1b0afcbd9d26221b7f692e500">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>